### PR TITLE
Add FactoryBotFactoryPropertyOrdered

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,9 @@ Style/FrozenStringLiteralComment:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/ParallelAssignment:
+  Enabled: false
+
 Style/RequireOrder:
   Enabled: true
   SafeAutoCorrect: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport
       rubocop
       rubocop-rails
+      sevencop
 
 GEM
   remote: https://rubygems.org/
@@ -99,6 +100,9 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sevencop (0.37.0)
+      activesupport
+      rubocop
     stringio (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Momocop/FactoryBotRailsFactoryAssociationsCoverage:
 
 |Cop|Rails|FactoryBot|
 |---|:-:|:-:|
+|[`Momocop/FactoryBotFactoryPropertyOrdered`](lib/rubocop/cop/momocop/factory_bot_factory_property_ordered.rb)|:white_check_mark:|:white_check_mark:|
 |[`Momocop/FactoryBotRailsClassOptionExistence`](lib/rubocop/cop/momocop/factory_bot_rails_class_option_existence.rb)|:white_check_mark:|:white_check_mark:|
 |[`Momocop/FactoryBotRailsClassOptionSpecified`](lib/rubocop/cop/momocop/factory_bot_rails_class_option_specified.rb)|:white_check_mark:|:white_check_mark:|
 |[`Momocop/FactoryBotRailsFactoryAssociationsCoverage`](lib/rubocop/cop/momocop/factory_bot_rails_factory_associations_coverage.rb)|:white_check_mark:|:white_check_mark:|

--- a/lib/momocop.rb
+++ b/lib/momocop.rb
@@ -8,6 +8,9 @@ require 'rubocop/cop/mixin/active_record_helper'
 require 'rubocop/rails/schema_loader'
 require 'rubocop/rails/schema_loader/schema'
 
+# sevencop
+require 'sevencop/cop_concerns'
+
 # Momocop
 require_relative 'momocop/association_extractor'
 require_relative 'momocop/config_injector'

--- a/lib/rubocop/cop/momocop/factory_bot_factory_property_ordered.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_factory_property_ordered.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Momocop
+      # Ensures that FactoryBot factories has ordered property definitions.
+      # 1. Associations should be defined before other properties.
+      # 2. Associations and properties should be defined in alphabetical order.
+      #
+      # @example
+      #   # bad
+      #   factory :user, class: 'User' do
+      #     address { '123 Main St' }
+      #     association :profile
+      #   end
+      #
+      #   # good
+      #   factory :user, class: 'User' do
+      #     association :profile
+      #     address { '123 Main St' }
+      #   end
+      #
+      #   # bad
+      #   factory :user, class: 'User' do
+      #     association :profile
+      #     association :account
+      #     zipcode { '111-1111' }
+      #     address { '123 Main St' }
+      #   end
+      #
+      #   # good
+      #   factory :user, class: 'User' do
+      #     association :account
+      #     association :profile
+      #     address { '123 Main St' }
+      #     zipcode { '111-1111' }
+      #   end
+      class FactoryBotFactoryPropertyOrdered < RuboCop::Cop::Base
+        extend AutoCorrector
+        include RangeHelp
+
+        include ::Sevencop::CopConcerns::Ordered
+
+        MSG = 'Sort properties and associations alphabetically.'
+
+        RESTRICT_ON_SEND = %i[factory].freeze
+
+        def on_send(node)
+          return unless inside_factory_bot_define?(node)
+
+          block_node = node.block_node
+          entire_definitions = defined_properties(block_node)
+
+          sections =
+            entire_definitions
+            .slice_when { |a, b| b.loc.last_line - a.loc.last_line > 1 }
+            .select { |definitions| definitions.size >= 2 }
+
+          sections.each do |definitions|
+            add_offense(definitions.last) do |corrector|
+              (a, b) =
+                definitions
+                .lazy
+                .each_cons(2)
+                .find { |a, b| (order(a) <=> order(b)) == 1 }
+
+              break unless a && b
+
+              swap(
+                range_with_comments_and_lines(a),
+                range_with_comments_and_lines(b),
+                corrector:
+              )
+            end
+          end
+        end
+
+        private def order(node)
+          group = definition_type(node) == :association ? 0 : 1
+          index = definition_name(node)
+          [group, index]
+        end
+
+        private def defined_properties(block_node)
+          body_node = block_node&.children&.last
+          body_node&.children&.select { |node| definition_node?(node) }
+        end
+
+        private def definition_node?(node)
+          node.send_type? || (node.block_type? && node.children.first.send_type?)
+        end
+
+        private def definition_type(node)
+          send_node = node.send_type? ? node : node.children.first
+          if %i[association sequence].include? send_node.method_name
+            send_node.method_name
+          else
+            :property
+          end
+        end
+
+        private def definition_name(node)
+          send_node = node.send_type? ? node : node.children.first
+          if %i[association sequence].include? send_node.method_name
+            send_node.arguments.first.value
+          else
+            send_node.method_name.to_sym
+          end
+        end
+
+        private def inside_factory_bot_define?(node)
+          ancestors = node.each_ancestor(:block).to_a
+          ancestors.any? { |ancestor| ancestor.method_name == :define && ancestor.receiver&.const_name == 'FactoryBot' }
+        end
+      end
+    end
+  end
+end

--- a/momocop.gemspec
+++ b/momocop.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/releases"
 
-  spec.files = Dir.chdir(__dir__) do
+  spec.files = Dir.chdir(__dir__) {
     `git ls-files -z`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
         f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
     end
-  end
+  }
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'rubocop'
   spec.add_runtime_dependency 'rubocop-rails'
+  spec.add_runtime_dependency 'sevencop'
 end

--- a/spec/rubocop/cop/momocop/factory_bot_factory_property_ordered_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_factory_property_ordered_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Momocop::FactoryBotFactoryPropertyOrdered, :config do
+  let(:config) { RuboCop::Config.new }
+
+  context 'when there are no property definitions' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        factory :user do
+        end
+      RUBY
+    end
+  end
+
+  describe 'association definitions' do
+    context 'has correct order' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          factory(:user) do
+            association(:a)
+            association(:b)
+          end
+        RUBY
+      end
+    end
+
+    context 'has incorrect order' do
+      it 'registers offense and corrects by order properties' do
+        expect_offense(<<~RUBY)
+          FactoryBot.define do
+            factory(:user) do
+              association(:d) {}
+              association(:b)
+              association(:c) {}
+              ^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+
+              association(:e)
+              association(:a) {}
+              ^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          FactoryBot.define do
+            factory(:user) do
+              association(:b)
+              association(:c) {}
+              association(:d) {}
+
+              association(:a) {}
+              association(:e)
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe 'property definitions' do
+    context 'has correct order' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          factory(:user) do
+            sequence(:a) { }
+            b { }
+            sequence(:c) { }
+            d { }
+          end
+        RUBY
+
+        expect_no_offenses(<<~RUBY)
+          factory(:user) do
+            c {}
+            d {}
+
+            a {}
+            b {}
+          end
+        RUBY
+      end
+    end
+
+    context 'has incorrect order' do
+      it 'registers offense and corrects by order properties' do
+        expect_offense(<<~RUBY)
+          FactoryBot.define do
+            factory(:user) do
+              sequence(:e)
+              f
+              sequence(:d)
+              ^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+
+              sequence(:b) { }
+              a { }
+              sequence(:c) { }
+              ^^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          FactoryBot.define do
+            factory(:user) do
+              sequence(:d)
+              sequence(:e)
+              f
+
+              a { }
+              sequence(:b) { }
+              sequence(:c) { }
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe 'association and property definitions' do
+    context 'has correct order' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          factory(:user) do
+            association(:c)
+            sequence(:a)
+            b { }
+          end
+        RUBY
+      end
+    end
+
+    context 'has incorrect order' do
+      it 'registers offense and corrects by order properties' do
+        expect_offense(<<~RUBY)
+          FactoryBot.define do
+            factory(:user) do
+              d { }
+              sequence(:e)
+              association(:f)
+              b { }
+              sequence(:a)
+              association(:c)
+              ^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+            end
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          FactoryBot.define do
+            factory(:user) do
+              association(:c)
+              association(:f)
+              sequence(:a)
+              b { }
+              d { }
+              sequence(:e)
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds the FactoryBotFactoryPropertyOrdered cop to the RuboCop configuration. The cop ensures that FactoryBot factories have ordered property definitions, with associations defined before other properties and all properties and associations sorted alphabetically.