### PR TITLE
Refactor FactoryBot cop names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All cops are disabled by default.
 require:
   - momocop
 
-Momocop/FactoryBotRailsFactoryAssociationsCoverage:
+Momocop/FactoryBotMissingAssociations:
   Enabled: true
 ```
 
@@ -32,11 +32,11 @@ Momocop/FactoryBotRailsFactoryAssociationsCoverage:
 
 |Cop|Rails|FactoryBot|
 |---|:-:|:-:|
-|[`Momocop/FactoryBotFactoryPropertyOrdered`](lib/rubocop/cop/momocop/factory_bot_factory_property_ordered.rb)|:white_check_mark:|:white_check_mark:|
-|[`Momocop/FactoryBotRailsClassOptionExistence`](lib/rubocop/cop/momocop/factory_bot_rails_class_option_existence.rb)|:white_check_mark:|:white_check_mark:|
-|[`Momocop/FactoryBotRailsClassOptionSpecified`](lib/rubocop/cop/momocop/factory_bot_rails_class_option_specified.rb)|:white_check_mark:|:white_check_mark:|
-|[`Momocop/FactoryBotRailsFactoryAssociationsCoverage`](lib/rubocop/cop/momocop/factory_bot_rails_factory_associations_coverage.rb)|:white_check_mark:|:white_check_mark:|
-|[`Momocop/FactoryBotRailsFactoryPropertiesCoverage`](lib/rubocop/cop/momocop/factory_bot_rails_factory_properties_coverage.rb)|:white_check_mark:|:white_check_mark:|
+|[`Momocop/FactoryBotPropertyOrder`](lib/rubocop/cop/momocop/factory_bot_property_order.rb)|:white_check_mark:|:white_check_mark:|
+|[`Momocop/FactoryBotClassExistence`](lib/rubocop/cop/momocop/factory_bot_class_existence.rb)|:white_check_mark:|:white_check_mark:|
+|[`Momocop/FactoryBotMissingClassOption`](lib/rubocop/cop/momocop/factory_bot_missing_class_option.rb)|:white_check_mark:|:white_check_mark:|
+|[`Momocop/FactoryBotMissingAssociations`](lib/rubocop/cop/momocop/factory_bot_missing_associations.rb)|:white_check_mark:|:white_check_mark:|
+|[`Momocop/FactoryBotMissingProperties`](lib/rubocop/cop/momocop/factory_bot_missing_properties.rb)|:white_check_mark:|:white_check_mark:|
 
 ## Contributing
 

--- a/lib/rubocop/cop/momocop/factory_bot_class_existence.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_class_existence.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good (if 'app/models/admin.rb' exists)
       #   factory :user, class: 'Admin' do
       #   end
-      class FactoryBotRailsClassOptionExistence < RuboCop::Cop::Base
+      class FactoryBotClassExistence < RuboCop::Cop::Base
         extend AutoCorrector
 
         MSG = 'Specified class does not exist. Please make sure that the class exists.'

--- a/lib/rubocop/cop/momocop/factory_bot_missing_associations.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_missing_associations.rb
@@ -23,7 +23,7 @@ module RuboCop
       #       association(:account)
       #     end
       #   end
-      class FactoryBotRailsFactoryAssociationsCoverage < RuboCop::Cop::Base
+      class FactoryBotMissingAssociations < RuboCop::Cop::Base
         include RuboCop::Cop::ActiveRecordHelper
         extend AutoCorrector
 

--- a/lib/rubocop/cop/momocop/factory_bot_missing_class_option.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_missing_class_option.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   factory :user, class: 'User' do
       #   end
-      class FactoryBotRailsClassOptionSpecified < RuboCop::Cop::Base
+      class FactoryBotMissingClassOption < RuboCop::Cop::Base
         extend AutoCorrector
 
         MSG = 'Specify a class option explicitly in FactoryBot factory.'

--- a/lib/rubocop/cop/momocop/factory_bot_missing_properties.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_missing_properties.rb
@@ -26,7 +26,7 @@ module RuboCop
       #       name { 'John Doe' }
       #     end
       #   end
-      class FactoryBotRailsFactoryPropertiesCoverage < RuboCop::Cop::Base
+      class FactoryBotMissingProperties < RuboCop::Cop::Base
         include RuboCop::Cop::ActiveRecordHelper
         extend AutoCorrector
 

--- a/lib/rubocop/cop/momocop/factory_bot_property_order.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_property_order.rb
@@ -35,7 +35,7 @@ module RuboCop
       #     address { '123 Main St' }
       #     zipcode { '111-1111' }
       #   end
-      class FactoryBotFactoryPropertyOrdered < RuboCop::Cop::Base
+      class FactoryBotPropertyOrder < RuboCop::Cop::Base
         extend AutoCorrector
         include RangeHelp
 

--- a/spec/rubocop/cop/momocop/factory_bot_class_existence_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_class_existence_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsClassOptionExistence, :config do
+RSpec.describe RuboCop::Cop::Momocop::FactoryBotClassExistence, :config do
   let(:config) { RuboCop::Config.new }
 
   context 'when class option is not a symbol or string' do
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsClassOptionExistence, :conf
         expect_offense(<<~RUBY)
           FactoryBot.define do
             factory(:user, class: :User) {}
-                                  ^^^^^ Momocop/FactoryBotRailsClassOptionExistence: Specified class does not exist. Please make sure that the class exists.
+                                  ^^^^^ Momocop/FactoryBotClassExistence: Specified class does not exist. Please make sure that the class exists.
           end
         RUBY
       end
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsClassOptionExistence, :conf
         expect_offense(<<~RUBY)
           FactoryBot.define do
             factory(:admin, class: 'User') {}
-                                   ^^^^^^ Momocop/FactoryBotRailsClassOptionExistence: Specified class does not exist. Please make sure that the class exists.
+                                   ^^^^^^ Momocop/FactoryBotClassExistence: Specified class does not exist. Please make sure that the class exists.
           end
         RUBY
       end

--- a/spec/rubocop/cop/momocop/factory_bot_missing_associations_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_missing_associations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage, :config do
+RSpec.describe RuboCop::Cop::Momocop::FactoryBotMissingAssociations, :config do
   let(:config) { RuboCop::Config.new }
 
   before do
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage
       expect_offense(<<~RUBY)
         FactoryBot.define do
           factory(:user, class: 'User') do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotRailsFactoryAssociationsCoverage: Ensure all associations of the model class are defined in the factory.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotMissingAssociations: Ensure all associations of the model class are defined in the factory.
             association(:account)
           end
         end
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage
       expect_offense(<<~RUBY)
         FactoryBot.define do
           factory(:user, class: 'User') {}
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotRailsFactoryAssociationsCoverage: Ensure all associations of the model class are defined in the factory.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotMissingAssociations: Ensure all associations of the model class are defined in the factory.
         end
       RUBY
 
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage
       expect_offense(<<~RUBY)
         FactoryBot.define do
           factory(:user, class: 'User')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotRailsFactoryAssociationsCoverage: Ensure all associations of the model class are defined in the factory.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotMissingAssociations: Ensure all associations of the model class are defined in the factory.
         end
       RUBY
 
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage
 
   describe '#model_file_path' do
     it 'returns correct file path' do
-      cop = RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage.new
+      cop = RuboCop::Cop::Momocop::FactoryBotMissingAssociations.new
       actual = cop.send(:model_file_path, 'User')
       expected = 'app/models/user.rb'
 

--- a/spec/rubocop/cop/momocop/factory_bot_missing_class_option_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_missing_class_option_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsClassOptionSpecified, :config do
+RSpec.describe RuboCop::Cop::Momocop::FactoryBotMissingClassOption, :config do
   let(:config) { RuboCop::Config.new }
 
   context 'when factory method does not specify a class option' do
@@ -8,14 +8,14 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsClassOptionSpecified, :conf
       expect_offense(<<~RUBY)
         FactoryBot.define do
           factory(:user) { }
-          ^^^^^^^ Momocop/FactoryBotRailsClassOptionSpecified: Specify a class option explicitly in FactoryBot factory.
+          ^^^^^^^ Momocop/FactoryBotMissingClassOption: Specify a class option explicitly in FactoryBot factory.
         end
       RUBY
 
       expect_offense(<<~RUBY)
         FactoryBot.define do
           factory :user do
-          ^^^^^^^ Momocop/FactoryBotRailsClassOptionSpecified: Specify a class option explicitly in FactoryBot factory.
+          ^^^^^^^ Momocop/FactoryBotMissingClassOption: Specify a class option explicitly in FactoryBot factory.
           end
         end
       RUBY

--- a/spec/rubocop/cop/momocop/factory_bot_missing_properties_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_missing_properties_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryPropertiesCoverage, :config do
+RSpec.describe RuboCop::Cop::Momocop::FactoryBotMissingProperties, :config do
   let(:config) { RuboCop::Config.new }
 
   before do
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryPropertiesCoverage, 
         expect_offense(<<~RUBY)
           FactoryBot.define do
             factory :user, class: 'User' do
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotRailsFactoryPropertiesCoverage: Ensure all properties of the model class are defined in the factory.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotMissingProperties: Ensure all properties of the model class are defined in the factory.
               name { 'Name' }
             end
           end
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotRailsFactoryPropertiesCoverage, 
 
   describe '#model_file_path' do
     it 'returns correct file path' do
-      cop = RuboCop::Cop::Momocop::FactoryBotRailsFactoryAssociationsCoverage.new
+      cop = RuboCop::Cop::Momocop::FactoryBotMissingAssociations.new
       actual = cop.send(:model_file_path, 'User')
       expected = 'app/models/user.rb'
 

--- a/spec/rubocop/cop/momocop/factory_bot_property_order_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_property_order_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Momocop::FactoryBotFactoryPropertyOrdered, :config do
+RSpec.describe RuboCop::Cop::Momocop::FactoryBotPropertyOrder, :config do
   let(:config) { RuboCop::Config.new }
 
   context 'when there are no property definitions' do
@@ -32,11 +32,11 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotFactoryPropertyOrdered, :config 
               association(:d) {}
               association(:b)
               association(:c) {}
-              ^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+              ^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotPropertyOrder: Sort properties and associations alphabetically.
 
               association(:e)
               association(:a) {}
-              ^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+              ^^^^^^^^^^^^^^^^^^ Momocop/FactoryBotPropertyOrder: Sort properties and associations alphabetically.
             end
           end
         RUBY
@@ -89,12 +89,12 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotFactoryPropertyOrdered, :config 
               sequence(:e)
               f
               sequence(:d)
-              ^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+              ^^^^^^^^^^^^ Momocop/FactoryBotPropertyOrder: Sort properties and associations alphabetically.
 
               sequence(:b) { }
               a { }
               sequence(:c) { }
-              ^^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+              ^^^^^^^^^^^^^^^^ Momocop/FactoryBotPropertyOrder: Sort properties and associations alphabetically.
             end
           end
         RUBY
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotFactoryPropertyOrdered, :config 
               b { }
               sequence(:a)
               association(:c)
-              ^^^^^^^^^^^^^^^ Momocop/FactoryBotFactoryPropertyOrdered: Sort properties and associations alphabetically.
+              ^^^^^^^^^^^^^^^ Momocop/FactoryBotPropertyOrder: Sort properties and associations alphabetically.
             end
           end
         RUBY


### PR DESCRIPTION
This PR updates the names of the FactoryBot cops to be more descriptive and consistent with the naming conventions.