### PR TITLE
Handle empty files and comment-only files in FactoryBotSingleDefinePerFile

### DIFF
--- a/lib/rubocop/cop/momocop/factory_bot_single_define_per_file.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_single_define_per_file.rb
@@ -32,6 +32,8 @@ module RuboCop
         MSG = 'Only one `FactoryBot.define` block is allowed per file.'
 
         def on_new_investigation
+          return unless processed_source.ast
+
           factory_bot_define_blocks =
             processed_source
             .ast

--- a/spec/rubocop/cop/momocop/factory_bot_single_define_per_file_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_single_define_per_file_spec.rb
@@ -35,4 +35,26 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotSingleDefinePerFile, :config do
       RUBY
     end
   end
+
+  context 'when file is empty' do
+    it 'registers no offense' do
+      expect_no_offenses('')
+    end
+  end
+
+  context 'when file contains only comments' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        # This is a comment
+        # Another comment line
+
+        =begin
+        This is a block comment
+        Multiple lines are allowed
+        =end
+
+        # Yet another comment
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
## 変更内容

- 空ファイルに対するテストケースを追加
- コメントのみのファイルに対するテストケースを追加
- ASTが nil の場合の早期リターン処理を追加してこれらのケースを適切に処理

## 確認内容

- すべてのテストケースが正常に通過することを確認済み
- 既存の機能に影響がないことを確認済み