### PR TITLE
Fix crash in FactoryBotSingleFactoryPerDefine on empty block

### DIFF
--- a/lib/rubocop/cop/momocop/factory_bot_single_factory_per_define.rb
+++ b/lib/rubocop/cop/momocop/factory_bot_single_factory_per_define.rb
@@ -65,12 +65,18 @@ module RuboCop
 
         # Returns all top-level factories within a FactoryBot.define block.
         private def top_level_factories(node)
+          block = node.block_node
+          return [] unless block
+
+          body = block.body
+          return [] unless body
+
           factory_nodes =
-            node
-            .block_node
-            .body.each_descendant(:send)
+            body
+            .each_descendant(:send)
             .select { |n| n.method_name == :factory }
-          factory_nodes.select { |factory_node|
+
+          factory_nodes.select do |factory_node|
             base_node = factory_node.block_node || factory_node
             context =
               base_node
@@ -78,7 +84,7 @@ module RuboCop
               .map { _1.send_node&.method_name&.to_sym }
               .find { %i[define factory].include? _1 }
             context == :define
-          }
+          end
         end
       end
     end

--- a/spec/rubocop/cop/momocop/factory_bot_single_factory_per_define_spec.rb
+++ b/spec/rubocop/cop/momocop/factory_bot_single_factory_per_define_spec.rb
@@ -63,4 +63,21 @@ RSpec.describe RuboCop::Cop::Momocop::FactoryBotSingleFactoryPerDefine, :config 
       RUBY
     end
   end
+
+  context 'when FactoryBot.define block is empty' do
+    it 'does not raise error and registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        FactoryBot.define do
+        end
+      RUBY
+    end
+  end
+
+  context 'when FactoryBot.define has no block' do
+    it 'does not raise error and registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        FactoryBot.define
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- avoid nil body crash in `FactoryBotSingleFactoryPerDefine`
- add regression specs for empty and blockless `FactoryBot.define`

## Testing
- `bundle exec rubocop`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_683fc5192f988321b0395476e51d7c14